### PR TITLE
Potential fix for code scanning alert no. 15: Log entries created from user input

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -17,6 +17,7 @@ package ogmigo
 import (
 	"bytes"
 	"log"
+	"strings"
 )
 
 type KeyValue struct {
@@ -54,7 +55,10 @@ func (d defaultLogger) print(message string, kvs ...KeyValue) {
 		buf.WriteString(" ")
 		buf.WriteString(kv.Key)
 		buf.WriteString("=")
-		buf.WriteString(kv.Value)
+		// Sanitize the value to remove newline characters
+		sanitizedValue := strings.ReplaceAll(kv.Value, "\n", "")
+		sanitizedValue = strings.ReplaceAll(sanitizedValue, "\r", "")
+		buf.WriteString(sanitizedValue)
 	}
 	log.Println(buf)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/blinklabs-io/sundaeswap-ogmigo/security/code-scanning/15](https://github.com/blinklabs-io/sundaeswap-ogmigo/security/code-scanning/15)

To fix the issue, we need to sanitize the user-provided input before it is logged. Specifically:
1. For plain text logs, remove newline characters (`\n` and `\r`) from the `KeyValue.Value` field to prevent log forgery.
2. Use `strings.ReplaceAll` to replace these characters with an empty string.
3. Apply this sanitization in the `defaultLogger.print` method, where the `KeyValue` pairs are processed before being written to the log.

This ensures that any user-provided input is sanitized before being logged, mitigating the risk of log forgery or injection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
